### PR TITLE
doc: update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@
 - Create separate PRs for each feature or fix. Avoid combining unrelated changes in a single PR
 - Consider allowing write access to your branch for faster reviews, as reviewers can push commits directly
 - If your PR becomes stale, don't hesitate to ping the maintainers in the comments
+- Hard forks of other people's original PRs are not allowed unless the hard fork PR with real breakthrough progress can be approved within a week
 
 # Pull requests (for collaborators)
 


### PR DESCRIPTION
*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

I have witnessed some of the things happening in this community in recent days. It seems that no one is speaking up for [zhouwg](https://github.com/jeffzhou2000).

I think Jeff really did make a mistake: 
- He shouldn't dropped some non-tech comments in  [discussions-14356](https://github.com/ggml-org/llama.cpp/discussions/14356) although he deleted on July 12 2025. 
- Jeff should not be in [the thread that has nothing to do with him](https://github.com/ggml-org/llama.cpp/discussions/14662). I know Jeff is a person with a strong sense of justice. He will express his opinions on things that he thinks are unreasonable even if doing so will bring him trouble. We can all see that the original author of ggml has warned/reminded Jeff not to post any non-technical comments in this tech community on July 12 2025, that's the ostensible direct reason why Jeff was blocked again on July 14 2025.

So the punishment for Jeff is make sense although to be fair it was too severe.

There is an interesting question: why Jeff dropped some non-tech comments in [discussions-14356](https://github.com/ggml-org/llama.cpp/discussions/14356) because I know Jeff is a typical tech-oriented and code-oriented programmer? 

_Blessed are the pure in heart, for they will see God.
Blessed are the peacemakers, for they will be called children of God.
Blessed are those who are persecuted because of righteousness, for theirs is the kingdom of heaven.
Matthew 5:8-10_

This PR attempts to resolve this long-term issue. As the original author of ggml said on July 12 2025:**_I think we try to accept all points of views_** . I think this PR may be a good thing for the entire community and prevent Jeff's tragedy from happening again if this PR can be approved, might-be a good thing for Jeff because I don't think Jeff's punishment will be lifted anytime soon.